### PR TITLE
Add timeline-map demo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,21 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #000;
+  color: #fff;
+}
+
+#timeline {
+  height: 35vh;
+  border-bottom: 2px solid #fff;
+}
+
+#map {
+  height: 65vh;
+}
+
+.vis-item {
+  color: #000;
+  background-color: #ff0;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Timeline Map</title>
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.css" />
+</head>
+<body>
+  <div id="timeline"></div>
+  <div id="map"></div>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.js"></script>
+  <script src="js/data.js"></script>
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/js/data.js
+++ b/js/data.js
@@ -1,0 +1,26 @@
+const events = [
+  {
+    id: 1,
+    content: 'Event 1',
+    start: '2024-01-01',
+    end: '2024-01-02',
+    latlng: [41.9, 12.5],
+    popup: 'Rome Event'
+  },
+  {
+    id: 2,
+    content: 'Event 2',
+    start: '2024-02-01',
+    end: '2024-02-02',
+    latlng: [48.8, 2.3],
+    popup: 'Paris Event'
+  },
+  {
+    id: 3,
+    content: 'Event 3',
+    start: '2024-03-01',
+    end: '2024-03-02',
+    latlng: [51.5, -0.1],
+    popup: 'London Event'
+  }
+];

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,32 @@
+// Initialize map
+const map = L.map('map').setView([41.9, 12.5], 5);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '© OpenStreetMap contributors'
+}).addTo(map);
+
+// Add markers and store references
+const markers = {};
+for (const evt of events) {
+  const marker = L.marker(evt.latlng).addTo(map).bindPopup(evt.popup);
+  markers[evt.id] = marker;
+  marker.on('click', () => {
+    timeline.setSelection(evt.id, { focus: true });
+  });
+}
+
+// Initialize timeline
+const container = document.getElementById('timeline');
+const items = new vis.DataSet(events);
+const options = {
+  height: '100%'
+};
+const timeline = new vis.Timeline(container, items, options);
+
+timeline.on('select', props => {
+  const id = props.items[0];
+  if (id && markers[id]) {
+    const marker = markers[id];
+    map.setView(marker.getLatLng(), 8);
+    marker.openPopup();
+  }
+});


### PR DESCRIPTION
## Summary
- create a high contrast layout
- add demo data for timeline events
- sync timeline and map interactions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684608ae2c0483269205dd34511088d5