### PR TITLE
Add BC date support and long-range timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # History
+
+Example timeline and map using **vis.js** and **Leaflet**. The dataset now
+includes events dating back to antiquity. Dates before the common era are
+expressed using negative years (e.g. `-0509-01-01` for 509&nbsp;BC) and are
+converted to JavaScript `Date` objects via a custom helper.

--- a/js/data.js
+++ b/js/data.js
@@ -1,23 +1,44 @@
 const events = [
   {
     id: 1,
-    content: 'Event 1',
+    content: 'Foundation of the Roman Republic',
+    start: '-0509-01-01',
+    latlng: [41.9, 12.5],
+    popup: 'Traditional date for the founding of the Roman Republic'
+  },
+  {
+    id: 2,
+    content: 'Assassination of Julius Caesar',
+    start: '-0044-03-15',
+    latlng: [41.9, 12.5],
+    popup: 'Julius Caesar killed in Rome'
+  },
+  {
+    id: 3,
+    content: 'Coronation of Charlemagne',
+    start: '0800-12-25',
+    latlng: [41.9, 12.5],
+    popup: 'Charlemagne crowned Emperor in Rome'
+  },
+  {
+    id: 4,
+    content: 'Event 4',
     start: '2024-01-01',
     end: '2024-01-02',
     latlng: [41.9, 12.5],
     popup: 'Rome Event'
   },
   {
-    id: 2,
-    content: 'Event 2',
+    id: 5,
+    content: 'Event 5',
     start: '2024-02-01',
     end: '2024-02-02',
     latlng: [48.8, 2.3],
     popup: 'Paris Event'
   },
   {
-    id: 3,
-    content: 'Event 3',
+    id: 6,
+    content: 'Event 6',
     start: '2024-03-01',
     end: '2024-03-02',
     latlng: [51.5, -0.1],

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,13 @@
+// Utility to create Date objects supporting negative years (e.g. "-0500-01-01")
+function parseDate(str) {
+  if (!str) return null;
+  const parts = str.split('-').map(Number);
+  const year = parts[0];
+  const month = parts[1] - 1 || 0;
+  const day = parts[2] || 1;
+  return new Date(year, month, day);
+}
+
 // Initialize map
 const map = L.map('map').setView([41.9, 12.5], 5);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -16,9 +26,19 @@ for (const evt of events) {
 
 // Initialize timeline
 const container = document.getElementById('timeline');
-const items = new vis.DataSet(events);
+const items = new vis.DataSet(
+  events.map(evt => ({
+    ...evt,
+    start: parseDate(evt.start),
+    end: evt.end ? parseDate(evt.end) : undefined
+  }))
+);
 const options = {
-  height: '100%'
+  height: '100%',
+  zoomMin: 1000 * 60 * 60 * 24 * 365 * 10, // 10 years
+  zoomMax: 1000 * 60 * 60 * 24 * 365 * 3000, // several millennia
+  start: parseDate('-0600-01-01'),
+  end: parseDate('2050-01-01')
 };
 const timeline = new vis.Timeline(container, items, options);
 


### PR DESCRIPTION
## Summary
- add demonstration events in antiquity
- support negative years with `parseDate`
- configure vis.js timeline for multi-century ranges
- document BC date handling

## Testing
- `node --check js/main.js`
- `node --check js/data.js`

------
https://chatgpt.com/codex/tasks/task_e_6846d7db9ed48326878265016e82e2e5