### PR TITLE
Add categories and region filtering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,5 +17,17 @@ html, body {
 
 .vis-item {
   color: #000;
-  background-color: #ff0;
+}
+
+.vis-item.category-war {
+  background-color: #f55;
+}
+
+.vis-item.category-empire {
+  background-color: #5f5;
+}
+
+.vis-item.category-migration {
+  background-color: #55f;
+  color: #fff;
 }

--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
   <link rel="stylesheet" href="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.css" />
 </head>
 <body>
+  <select id="regionFilter">
+    <option value="all">All regions</option>
+    <option value="italy">Italy</option>
+    <option value="france">France</option>
+    <option value="uk">UK</option>
+  </select>
   <div id="timeline"></div>
   <div id="map"></div>
 

--- a/js/data.js
+++ b/js/data.js
@@ -5,7 +5,9 @@ const events = [
     start: '2024-01-01',
     end: '2024-01-02',
     latlng: [41.9, 12.5],
-    popup: 'Rome Event'
+    popup: 'Rome Event',
+    category: 'empire',
+    region: 'italy'
   },
   {
     id: 2,
@@ -13,7 +15,9 @@ const events = [
     start: '2024-02-01',
     end: '2024-02-02',
     latlng: [48.8, 2.3],
-    popup: 'Paris Event'
+    popup: 'Paris Event',
+    category: 'war',
+    region: 'france'
   },
   {
     id: 3,
@@ -21,6 +25,8 @@ const events = [
     start: '2024-03-01',
     end: '2024-03-02',
     latlng: [51.5, -0.1],
-    popup: 'London Event'
+    popup: 'London Event',
+    category: 'migration',
+    region: 'uk'
   }
 ];

--- a/js/main.js
+++ b/js/main.js
@@ -4,23 +4,46 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© OpenStreetMap contributors'
 }).addTo(map);
 
-// Add markers and store references
+// Prepare markers for all events
 const markers = {};
 for (const evt of events) {
-  const marker = L.marker(evt.latlng).addTo(map).bindPopup(evt.popup);
+  const marker = L.marker(evt.latlng).bindPopup(evt.popup);
   markers[evt.id] = marker;
   marker.on('click', () => {
     timeline.setSelection(evt.id, { focus: true });
   });
 }
 
-// Initialize timeline
+// Initialize timeline and groups
 const container = document.getElementById('timeline');
-const items = new vis.DataSet(events);
-const options = {
-  height: '100%'
-};
-const timeline = new vis.Timeline(container, items, options);
+const items = new vis.DataSet();
+const groups = new vis.DataSet();
+let currentEvents = events.slice();
+
+function buildDatasets(list) {
+  items.clear();
+  groups.clear();
+  const cats = new Set();
+  for (const evt of list) {
+    items.add({
+      id: evt.id,
+      content: evt.content,
+      start: evt.start,
+      end: evt.end,
+      group: evt.category,
+      className: 'category-' + evt.category
+    });
+    cats.add(evt.category);
+  }
+  for (const c of cats) {
+    groups.add({ id: c, content: c });
+  }
+}
+
+buildDatasets(currentEvents);
+
+const timeline = new vis.Timeline(container, items, { height: '100%' });
+timeline.setGroups(groups);
 
 timeline.on('select', props => {
   const id = props.items[0];
@@ -30,3 +53,35 @@ timeline.on('select', props => {
     marker.openPopup();
   }
 });
+
+function updateMarkers(list) {
+  const visible = new Set(list.map(e => e.id));
+  for (const [id, marker] of Object.entries(markers)) {
+    if (visible.has(Number(id))) {
+      if (!map.hasLayer(marker)) marker.addTo(map);
+    } else if (map.hasLayer(marker)) {
+      map.removeLayer(marker);
+    }
+  }
+}
+
+const regionFilter = document.getElementById('regionFilter');
+regionFilter.addEventListener('change', applyFilter);
+
+function applyFilter() {
+  const region = regionFilter.value;
+  currentEvents = region === 'all' ? events : events.filter(e => e.region === region);
+  buildDatasets(currentEvents);
+  timeline.setGroups(groups);
+  timeline.fit();
+  updateMarkers(currentEvents);
+}
+
+timeline.on('rangechanged', props => {
+  const start = props.start;
+  const end = props.end;
+  const list = currentEvents.filter(e => new Date(e.start) <= end && new Date(e.end) >= start);
+  updateMarkers(list);
+});
+
+updateMarkers(currentEvents);


### PR DESCRIPTION
## Summary
- extend sample events with `category` and `region`
- color timeline items by category
- add region filter selector
- group timeline items by category and keep map markers synced

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d7dd78ac83268273abda50877983