### PR TITLE
Add timeline position indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,9 +6,24 @@ html, body {
   color: #fff;
 }
 
-#timeline {
+
+#timeline-container {
+  position: relative;
   height: 35vh;
   border-bottom: 2px solid #fff;
+}
+
+#timeline {
+  height: 100%;
+}
+
+#indicator {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: red;
+  pointer-events: none;
 }
 
 #map {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
   <link rel="stylesheet" href="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.css" />
 </head>
 <body>
-  <div id="timeline"></div>
+  <div id="timeline-container">
+    <div id="timeline"></div>
+    <div id="indicator"></div>
+  </div>
   <div id="map"></div>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -15,12 +15,40 @@ for (const evt of events) {
 }
 
 // Initialize timeline
-const container = document.getElementById('timeline');
+const timelineEl = document.getElementById('timeline');
+const timelineContainer = document.getElementById('timeline-container');
+const indicator = document.getElementById('indicator');
+
 const items = new vis.DataSet(events);
 const options = {
   height: '100%'
 };
-const timeline = new vis.Timeline(container, items, options);
+const timeline = new vis.Timeline(timelineEl, items, options);
+
+// calculate global time range
+let minTime = Infinity;
+let maxTime = -Infinity;
+for (const evt of events) {
+  const start = new Date(evt.start).getTime();
+  const end = new Date(evt.end).getTime();
+  if (start < minTime) minTime = start;
+  if (end < minTime) minTime = end;
+  if (start > maxTime) maxTime = start;
+  if (end > maxTime) maxTime = end;
+}
+minTime = new Date(minTime);
+maxTime = new Date(maxTime);
+
+function updateIndicator() {
+  const windowRange = timeline.getWindow();
+  const center = new Date((windowRange.start.getTime() + windowRange.end.getTime()) / 2);
+  const progress = (center - minTime) / (maxTime - minTime);
+  const width = timelineContainer.clientWidth;
+  indicator.style.left = (progress * width) + 'px';
+}
+
+timeline.on('rangechanged', updateIndicator);
+updateIndicator();
 
 timeline.on('select', props => {
   const id = props.items[0];


### PR DESCRIPTION
## Summary
- wrap timeline in a positioned container
- style a vertical indicator overlay
- compute dataset range and update the indicator position when the timeline zooms or scrolls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d7e160a88326be86de804e8637e4