### PR TITLE
Add empire polygons controlled by timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.js"></script>
   <script src="js/data.js"></script>
+  <script src="js/empires.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/empires.js
+++ b/js/empires.js
@@ -1,0 +1,44 @@
+const empires = [
+  {
+    name: 'Imperium Italicum',
+    start: '2024-01-01',
+    end: '2024-01-31',
+    coordinates: [
+      [
+        [42, 10],
+        [42, 15],
+        [48, 15],
+        [48, 10]
+      ]
+    ],
+    style: { color: '#ff0000', weight: 2, fillColor: '#ff0000', fillOpacity: 0.3 }
+  },
+  {
+    name: 'Regnum Francorum',
+    start: '2024-02-01',
+    end: '2024-02-28',
+    coordinates: [
+      [
+        [46, -5],
+        [46, 5],
+        [51, 5],
+        [51, -5]
+      ]
+    ],
+    style: { color: '#0000ff', weight: 2, fillColor: '#0000ff', fillOpacity: 0.3 }
+  },
+  {
+    name: 'Britannia',
+    start: '2024-03-01',
+    end: '2024-03-31',
+    coordinates: [
+      [
+        [52, -6],
+        [52, 2],
+        [58, 2],
+        [58, -6]
+      ]
+    ],
+    style: { color: '#00ff00', weight: 2, fillColor: '#00ff00', fillOpacity: 0.3 }
+  }
+];

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,13 @@ for (const evt of events) {
   });
 }
 
+// Prepare empire layers
+const empireLayers = {};
+for (const emp of empires) {
+  const layer = L.polygon(emp.coordinates, emp.style).bindPopup(emp.name);
+  empireLayers[emp.name] = layer;
+}
+
 // Initialize timeline
 const container = document.getElementById('timeline');
 const items = new vis.DataSet(events);
@@ -30,3 +37,25 @@ timeline.on('select', props => {
     marker.openPopup();
   }
 });
+
+function updateEmpires() {
+  const range = timeline.getWindow();
+  const start = range.start;
+  const end = range.end;
+  for (const emp of empires) {
+    const empStart = new Date(emp.start);
+    const empEnd = new Date(emp.end);
+    const layer = empireLayers[emp.name];
+    const visible = empEnd >= start && empStart <= end;
+    if (visible) {
+      if (!map.hasLayer(layer)) {
+        layer.addTo(map);
+      }
+    } else if (map.hasLayer(layer)) {
+      map.removeLayer(layer);
+    }
+  }
+}
+
+timeline.on('rangechanged', updateEmpires);
+updateEmpires();


### PR DESCRIPTION
## Summary
- add a dataset `js/empires.js` with polygons and temporal intervals
- load this dataset in `index.html`
- render polygons in `main.js` and toggle them when the timeline range changes

## Testing
- `node -c js/main.js`
- `node -c js/empires.js`
- `node -c js/data.js`


------
https://chatgpt.com/codex/tasks/task_e_6846d7e230348326b6e63f94bef918de