### PR TITLE
Add timeline center arrow with year label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,8 +21,33 @@ html, body {
   position: absolute;
   top: 0;
   bottom: 0;
+  left: 50%;
   width: 2px;
+  margin-left: -1px;
   background: red;
+  pointer-events: none;
+}
+
+#indicator::after {
+  content: '';
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-left: 6px solid transparent;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid red;
+}
+
+#year-label {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  padding: 2px 6px;
+  font-size: 14px;
   pointer-events: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <div id="timeline-container">
     <div id="timeline"></div>
     <div id="indicator"></div>
+    <div id="year-label"></div>
   </div>
   <div id="map"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -26,6 +26,7 @@ for (const emp of empires) {
 const timelineEl = document.getElementById('timeline');
 const timelineContainer = document.getElementById('timeline-container');
 const indicator = document.getElementById('indicator');
+const yearLabel = document.getElementById('year-label');
 
 const items = new vis.DataSet(events);
 const options = {
@@ -50,9 +51,7 @@ maxTime = new Date(maxTime);
 function updateIndicator() {
   const windowRange = timeline.getWindow();
   const center = new Date((windowRange.start.getTime() + windowRange.end.getTime()) / 2);
-  const progress = (center - minTime) / (maxTime - minTime);
-  const width = timelineContainer.clientWidth;
-  indicator.style.left = (progress * width) + 'px';
+  yearLabel.textContent = center.getFullYear();
 }
 
 timeline.on('rangechanged', updateIndicator);


### PR DESCRIPTION
## Summary
- add centered indicator arrow in CSS and fixed position
- display current year with a new label element
- update script to show year when scrolling
- include year label element in HTML layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d60165108326bd645c283c317bd0