### PR TITLE
Add object dataset with timeline-based display

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Empires are defined in `js/empires.js`. Each entry contains a list of
 `updateEmpires()` chooses the segment that overlaps the visible timeline range
 and updates the displayed geometry accordingly.
 
+## Object Dataset Format
+
+Additional map objects are defined in `js/objects.js`. Each object has a
+`start` and `end` date, a `type` (`"marker"`, `"polyline"` or `"polygon"`) and the
+geometry information required for that type. Markers use a single `latlng`
+coordinate while polylines and polygons use `coordinates` arrays. Optional
+properties such as `popup` text or a Leaflet `style` object control how the
+object is displayed. `updateObjects()` shows or hides these layers based on the
+visible timeline range.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <script src="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.js"></script>
   <script src="js/data.js"></script>
   <script src="js/empires.js"></script>
+  <script src="js/objects.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,23 @@ for (const emp of empires) {
   empireLayers[emp.name] = { layer, currentSegment: null };
 }
 
+// Prepare additional object layers
+const objectLayers = [];
+for (const obj of objects) {
+  let layer;
+  if (obj.type === 'marker') {
+    layer = L.marker(obj.latlng, obj.style);
+  } else if (obj.type === 'polyline') {
+    layer = L.polyline(obj.coordinates, obj.style);
+  } else if (obj.type === 'polygon') {
+    layer = L.polygon(obj.coordinates, obj.style);
+  }
+  if (obj.popup) {
+    layer.bindPopup(obj.popup);
+  }
+  objectLayers.push({ obj, layer });
+}
+
 // Initialize timeline
 const timelineEl = document.getElementById('timeline');
 const timelineContainer = document.getElementById('timeline-container');
@@ -100,5 +117,27 @@ function updateEmpires() {
   }
 }
 
+function updateObjects() {
+  const range = timeline.getWindow();
+  const start = range.start;
+  const end = range.end;
+
+  for (const item of objectLayers) {
+    const obj = item.obj;
+    const layer = item.layer;
+    const objStart = new Date(obj.start);
+    const objEnd = new Date(obj.end);
+    if (objEnd >= start && objStart <= end) {
+      if (!map.hasLayer(layer)) {
+        layer.addTo(map);
+      }
+    } else if (map.hasLayer(layer)) {
+      map.removeLayer(layer);
+    }
+  }
+}
+
 timeline.on('rangechanged', updateEmpires);
+timeline.on('rangechanged', updateObjects);
 updateEmpires();
+updateObjects();

--- a/js/objects.js
+++ b/js/objects.js
@@ -1,0 +1,34 @@
+const objects = [
+  {
+    start: '2024-01-05',
+    end: '2024-01-20',
+    type: 'marker',
+    latlng: [40, 10],
+    popup: 'Sample Marker'
+  },
+  {
+    start: '2024-02-10',
+    end: '2024-02-25',
+    type: 'polyline',
+    coordinates: [
+      [48, 12],
+      [50, 12],
+      [51, 13]
+    ],
+    style: { color: '#ff8800' }
+  },
+  {
+    start: '2024-03-10',
+    end: '2024-03-20',
+    type: 'polygon',
+    coordinates: [
+      [
+        [45, -2],
+        [45, 2],
+        [47, 2],
+        [47, -2]
+      ]
+    ],
+    style: { color: '#8800ff', weight: 2, fillColor: '#8800ff', fillOpacity: 0.3 }
+  }
+];


### PR DESCRIPTION
## Summary
- create `js/objects.js` dataset for markers, polylines and polygons
- load `objects.js` in `index.html`
- show and hide extra objects according to the timeline range
- document the object dataset format in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855d80801e883269203b0e1da50fc42