### PR TITLE
Fix timeline arrow visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,7 @@ html, body {
   width: 2px;
   margin-left: -1px;
   background: red;
+  z-index: 10;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- ensure the indicator element layers above the timeline content

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6855dcb6ff148326a1d6ff1bfd75fc12