### PR TITLE
Pin vis-timeline version

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <title>Timeline Map</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
-  <link rel="stylesheet" href="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/vis-timeline@7.7.0/dist/vis-timeline-graph2d.min.css" />
   <style>
     html, body {
       margin: 0;
@@ -107,7 +107,7 @@
   <div id="map"></div>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <script src="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.js"></script>
+  <script src="https://unpkg.com/vis-timeline@7.7.0/dist/vis-timeline-graph2d.min.js"></script>
 
   <script>
     // --- START OF data.js ---


### PR DESCRIPTION
## Summary
- lock vis-timeline dependency to version 7.7.0

## Testing
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6859c7fb8a488326a5f32aa5dafbe6cc