### PR TITLE
Fix vis-timeline version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ to see the updated map.
 
 ## Browser Requirements
 
-The application uses [Leaflet](https://leafletjs.com/) 1.9.4 and the latest
-version of [vis-timeline](https://visjs.github.io/vis-timeline/). A modern
+The application uses [Leaflet](https://leafletjs.com/) 1.9.4 and
+[vis-timeline](https://visjs.github.io/vis-timeline/) 7.7.0. A modern
 browser with ES6 support such as recent versions of Chrome, Firefox or Edge is
 recommended.
 

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
   <div id="map"></div>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <script src="https://unpkg.com/vis-timeline@latest/dist/vis-timeline-graph2d.min.js"></script>
+  <script src="https://unpkg.com/vis-timeline@7.7.0/dist/vis-timeline-graph2d.min.js"></script>
 
   <script>
     // --- START OF data.js ---


### PR DESCRIPTION
## Summary
- pin vis-timeline script to v7.7.0
- document vis-timeline 7.7.0 in Browser Requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859dd5a93e88326b85480e9b05b54ad