### PR TITLE
Allow unlimited timeline panning

### DIFF
--- a/index.html
+++ b/index.html
@@ -439,8 +439,6 @@
       const timelineItems = new vis.DataSet(events);
       const timelineOptions = {
         height: '100%',
-        min: timelineMin,
-        max: timelineMax,
         start: timelineMin,
         end: new Date(Math.max(timelineMin.getTime() + (30 * 24 * 60 * 60 * 1000), timelineMax.getTime())), // Ensure at least a 30-day window or full range
         zoomMin: 1000 * 60 * 60 * 24 * 7, // Minimum zoom level: 1 week

--- a/js/main.js
+++ b/js/main.js
@@ -97,8 +97,6 @@ const yearLabel = document.getElementById('year-label');
 const items = new vis.DataSet(events);
 const options = {
   height: '100%',
-  min: timelineMin,
-  max: timelineMax,
   start: timelineMin,
   end: new Date(Math.max(timelineMin.getTime() + (30 * 24 * 60 * 60 * 1000), timelineMax.getTime())),
   zoomMin: 1000 * 60 * 60 * 24 * 7,


### PR DESCRIPTION
## Summary
- remove `min` and `max` limits from the timeline options in `main.js`
- remove the same limits in the inline script in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68664542e9608326b10c27abb78f5136