### PR TITLE
Add BC date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ visible timeline range.
   the `objects` array. They use `start` and `end` dates along with geometry and
   optional `style` and `popup` properties.
 
+Dates may also represent BC years by prefixing the year with a minus sign,
+e.g. `-44-03-15` for 44&nbsp;BC. These values are parsed automatically.
+
 Edit these files to add or update entries. Reload the page after making changes
 to see the updated map.
 

--- a/index.html
+++ b/index.html
@@ -348,6 +348,17 @@
         attribution: '© OpenStreetMap contributors'
       }).addTo(map);
 
+      function parseDate(str) {
+        if (typeof str === 'string' && str.startsWith('-')) {
+          const parts = str.slice(1).split('-');
+          const year = -Number(parts[0]);
+          const month = Number(parts[1] || 1);
+          const day = Number(parts[2] || 1);
+          return new Date(year, month - 1, day);
+        }
+        return new Date(str);
+      }
+
       // Add event markers and store references
       const eventMarkers = {};
       for (const evt of events) {
@@ -402,13 +413,13 @@
 
       function updateOverallTimeRange(startTimeStr, endTimeStr) {
         if (startTimeStr) {
-          const startTime = new Date(startTimeStr).getTime();
+          const startTime = parseDate(startTimeStr).getTime();
           if (!isNaN(startTime) && startTime < minTimelineEdge) {
             minTimelineEdge = startTime;
           }
         }
         if (endTimeStr) {
-          const endTime = new Date(endTimeStr).getTime();
+          const endTime = parseDate(endTimeStr).getTime();
           if (!isNaN(endTime) && endTime > maxTimelineEdge) {
             maxTimelineEdge = endTime;
           }
@@ -490,8 +501,8 @@
           const layer = info.layer;
           let activeSegment = null;
           for (const s of emp.segments) {
-            const segStart = new Date(s.start);
-            const segEnd = new Date(s.end);
+            const segStart = parseDate(s.start);
+            const segEnd = parseDate(s.end);
             // Check for overlap: (SegStart <= ViewEnd) and (SegEnd >= ViewStart)
             if (segStart <= viewEnd && segEnd >= viewStart) {
               activeSegment = s;
@@ -517,8 +528,8 @@
         for (const item of objectLayers) {
           const obj = item.obj;
           const layer = item.layer;
-          const objStart = new Date(obj.start);
-          const objEnd = new Date(obj.end);
+          const objStart = parseDate(obj.start);
+          const objEnd = parseDate(obj.end);
           // Check for overlap: (ObjStart <= ViewEnd) and (ObjEnd >= ViewStart)
           if (objStart <= viewEnd && objEnd >= viewStart) {
             if (!map.hasLayer(layer)) {

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,18 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© OpenStreetMap contributors'
 }).addTo(map);
 
+// Helper to parse dates including negative years (BC)
+function parseDate(str) {
+  if (typeof str === 'string' && str.startsWith('-')) {
+    const parts = str.slice(1).split('-');
+    const year = -Number(parts[0]);
+    const month = Number(parts[1] || 1);
+    const day = Number(parts[2] || 1);
+    return new Date(year, month - 1, day);
+  }
+  return new Date(str);
+}
+
 // Add markers and store references
 const markers = {};
 for (const evt of events) {
@@ -45,13 +57,13 @@ let maxTimelineEdge = new Date('0000-01-01').getTime();
 
 function updateOverallTimeRange(startTimeStr, endTimeStr) {
   if (startTimeStr) {
-    const startTime = new Date(startTimeStr).getTime();
+    const startTime = parseDate(startTimeStr).getTime();
     if (!isNaN(startTime) && startTime < minTimelineEdge) {
       minTimelineEdge = startTime;
     }
   }
   if (endTimeStr) {
-    const endTime = new Date(endTimeStr).getTime();
+    const endTime = parseDate(endTimeStr).getTime();
     if (!isNaN(endTime) && endTime > maxTimelineEdge) {
       maxTimelineEdge = endTime;
     }
@@ -146,8 +158,8 @@ function updateEmpires() {
 
     let seg = null;
     for (const s of emp.segments) {
-      const segStart = new Date(s.start);
-      const segEnd = new Date(s.end);
+      const segStart = parseDate(s.start);
+      const segEnd = parseDate(s.end);
       if (segEnd >= start && segStart <= end) {
         seg = s;
         break;
@@ -177,8 +189,8 @@ function updateObjects() {
   for (const item of objectLayers) {
     const obj = item.obj;
     const layer = item.layer;
-    const objStart = new Date(obj.start);
-    const objEnd = new Date(obj.end);
+    const objStart = parseDate(obj.start);
+    const objEnd = parseDate(obj.end);
     if (objEnd >= start && objStart <= end) {
       if (!map.hasLayer(layer)) {
         layer.addTo(map);


### PR DESCRIPTION
## Summary
- add `parseDate` to handle negative years
- use `parseDate` for events, empires and objects in main.js and inline script
- document negative year support in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6866561438cc8326baf73bc4c5a42f9f