### PR TITLE
Add library check before timeline init

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,6 +534,11 @@
         timelineOptions.end = new Date(timelineOptions.start.getTime() + 30 * 24 * 60 * 60 * 1000); // Add 30 days
       }
 
+      if (!window.vis) {
+        console.warn('Timeline library failed to load');
+        yearLabel.textContent = 'Timeline library failed to load';
+        return;
+      }
 
       const timeline = new vis.Timeline(timelineEl, timelineItems, timelineOptions);
 

--- a/js/main.js
+++ b/js/main.js
@@ -148,6 +148,12 @@ if (options.end.getTime() <= options.start.getTime()) {
   options.end = new Date(options.start.getTime() + 30 * 24 * 60 * 60 * 1000);
 }
 
+if (!window.vis) {
+  console.warn('Timeline library failed to load');
+  yearLabel.textContent = 'Timeline library failed to load';
+  return;
+}
+
 const timeline = new vis.Timeline(timelineEl, items, options);
 
 function updateIndicator() {


### PR DESCRIPTION
## Summary
- guard against vis-timeline failing to load
- show a message when the timeline library is missing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866612fb8b48326ad5459ad8873c167