### PR TITLE
Remove DOMContentLoaded wrapper from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,7 +394,6 @@
 
   <script>
     // --- START OF main.js (corrected and enhanced) ---
-    document.addEventListener('DOMContentLoaded', function () {
       // Initialize map
       const map = L.map('map').setView([45, 5], 4); // Wider initial view
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -660,7 +659,6 @@
         updateMapLayers();
       }, 100);
 
-    });
     // --- END OF main.js ---
   </script>
 </body>


### PR DESCRIPTION
## Summary
- drop the DOMContentLoaded listener so inline scripts run immediately

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866617c77288326b2340b0dc47cbbf8