### PR TITLE
Fix missing libraries by using CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Visit the live map at <https://vitopalumbopodcast.github.io/History/>.
 
 ## Serving the Site Locally
 
-The project is a static website. From the repository root run:
+The page now loads Leaflet, vis-timeline and the polyline decorator from
+public CDNs, so you can open `index.html` directly in any modern browser.
+If you prefer to run a small local server, from the repository root run:
 
 ```bash
 python -m http.server
@@ -73,10 +75,10 @@ recommended.
 
 ## Updating Vendor Libraries
 
-Local copies of Leaflet, Leaflet PolylineDecorator and vis-timeline are kept in
-the `vendor/` directory so the site works without internet access. To update to
-a newer release or replace the files, download the desired versions from the
-official projects and overwrite the corresponding files:
+The `vendor/` directory contains placeholder files for Leaflet,
+Leaflet PolylineDecorator and vis-timeline. Replace them with the real library
+files if you need to work completely offline. Download the desired versions
+from the official projects and overwrite the corresponding files:
 
 ```
 vendor/leaflet/leaflet.js

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Timeline Map</title>
-  <link rel="stylesheet" href="vendor/leaflet/leaflet.css" />
-  <link rel="stylesheet" href="vendor/vis-timeline/vis-timeline-graph2d.min.css" />
+  <!-- Load libraries from CDN -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="https://unpkg.com/vis-timeline@7.7.0/dist/vis-timeline-graph2d.min.css" />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -15,9 +16,10 @@
     <div id="year-label">Loading...</div>
   </div>
   <div id="map"></div>
-  <script src="vendor/leaflet/leaflet.js"></script>
-  <script src="vendor/leaflet-polylinedecorator/leaflet.polylineDecorator.min.js"></script>
-  <script src="vendor/vis-timeline/vis-timeline-graph2d.min.js"></script>
+  <!-- Load JS libraries from CDN -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet-polylinedecorator@1.7.0/dist/leaflet.polylineDecorator.min.js"></script>
+  <script src="https://unpkg.com/vis-timeline@7.7.0/dist/vis-timeline-graph2d.min.js"></script>
   <script src="js/data.js"></script>
   <script src="js/empires.js"></script>
   <script src="js/objects.js"></script>


### PR DESCRIPTION
## Summary
- load Leaflet and vis-timeline from CDNs
- note CDN loading and offline vendor files in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68667aadeb34832686083e9982fa1696