### PR TITLE
Add curved arrow for Dorian migration

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -70,7 +70,7 @@ for (const obj of objects) {
     layer = L.polyline(obj.coordinates, obj.style);
     if (obj.decorated) {
       if (typeof L.polylineDecorator === 'function') {
-        decorator = L.polylineDecorator(layer, {
+        const decoOpts = obj.decoratorOptions || {
           patterns: [
             {
               offset: '5%',
@@ -82,7 +82,8 @@ for (const obj of objects) {
               })
             }
           ]
-        });
+        };
+        decorator = L.polylineDecorator(layer, decoOpts);
       } else {
         console.warn('Leaflet polylineDecorator plugin is not available - skipping decoration');
       }

--- a/js/objects.js
+++ b/js/objects.js
@@ -54,12 +54,31 @@ const objects = [
     type: 'polyline',
     coordinates: [
       [40.5, 22.0], // Thessaly/Macedonia
+      [39.8, 21.8], // gentle curve southward
       [39.3, 21.0], // Pindus region
+      [38.8, 21.5], // continue curve
       [37.5, 22.0]  // Peloponneso
     ],
-    style: { color: '#00ffff', weight: 2 },
+    style: { color: '#00ffff', weight: 4 },
     popup: 'Dorian migration path (~1200-1000 BC)',
-    decorated: true
+    decorated: true,
+    decoratorOptions: {
+      patterns: [
+        {
+          offset: '100%',
+          repeat: 0,
+          symbol: L.Symbol.arrowHead({
+            pixelSize: 15,
+            polygon: true,
+            pathOptions: {
+              stroke: true,
+              color: '#00ffff',
+              fillOpacity: 1
+            }
+          })
+        }
+      ]
+    }
   },
   {
     start: '-1000-01-01',


### PR DESCRIPTION
## Summary
- allow objects to specify custom `decoratorOptions`
- draw Dorian migration as a thicker curved arrow with a single head

## Testing
- `node --check js/main.js && node --check js/objects.js`

------
https://chatgpt.com/codex/tasks/task_e_686bf92ec15c8326be34d5bbbb88abf2