### PR TITLE
Improve arrowHead defaults

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -76,8 +76,8 @@ for (const obj of objects) {
               offset: '5%',
               repeat: '10%',
               symbol: L.Symbol.arrowHead({
-                pixelSize: 8,
-                polygon: false,
+                pixelSize: 12,
+                polygon: true,
                 pathOptions: { stroke: true, color: layer.options.color || '#000' }
               })
             }


### PR DESCRIPTION
## Summary
- update `arrowHead` defaults in `main.js` so the tips are filled and bigger

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bfc5e7ca88326a6e9c838e9332503